### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ func_timeout
 deepspeed
 accelerate>=0.25.0
 gradio>=3.41.2
-diffusers>=0.28.2
+diffusers>=0.30.1
 transformers>=4.37.2


### PR DESCRIPTION
An error occurs when diffusers version is 0.28.2:     
from diffusers import (AutoencoderKL, CogVideoXDDIMScheduler, DDIMScheduler, ImportError: cannot import name 'CogVideoXDDIMScheduler' from 'diffusers'